### PR TITLE
Implement Kafka consumer uploading to Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# kafka-python-2
-consumer application python
+# Kafka Python Consumer to Azure
+
+This repository provides a small example application that consumes JSON
+messages from a Kafka topic and uploads each message to Azure Blob Storage
+using `azcopy`.
+
+## Running the consumer
+
+```
+python -m kafka_azure_consumer.consumer
+```
+
+Configure the connection details by editing the `ConsumerConfig` instance in
+your own script.
+
+## Running tests
+
+Tests use the built in `unittest` framework:
+
+```
+python -m unittest discover -v
+```

--- a/kafka_azure_consumer/consumer.py
+++ b/kafka_azure_consumer/consumer.py
@@ -1,0 +1,100 @@
+"""Kafka consumer that uploads messages to Azure Blob Storage."""
+
+import json  # For decoding JSON messages
+import logging  # Standard logging library
+import subprocess  # Used to invoke azcopy
+from dataclasses import dataclass
+from typing import Optional
+
+from kafka import KafkaConsumer  # Kafka client library
+
+# Configure root logger to output debug statements
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class ConsumerConfig:
+    """Configuration options for :class:`KafkaAzureConsumer`."""
+
+    # Address of Kafka brokers, e.g. 'localhost:9092'
+    bootstrap_servers: str
+    # Topic to subscribe to
+    topic: str
+    # Destination Azure Blob container SAS URL
+    azure_container_url: str
+    # Location of the azcopy binary
+    azcopy_path: str = "azcopy"
+
+
+class KafkaAzureConsumer:
+    """Consume JSON messages from Kafka and upload them to Azure Blob storage."""
+
+    def __init__(self, config: ConsumerConfig):
+        """Initialize the consumer with the provided configuration."""
+
+        # Store configuration for later use
+        self.config = config
+        # Will hold the KafkaConsumer instance once connected
+        self.consumer: Optional[KafkaConsumer] = None
+
+    def connect(self) -> None:
+        """Create a ``KafkaConsumer`` instance and subscribe to the topic."""
+
+        try:
+            # Instantiate kafka consumer using provided configuration.
+            # The value_deserializer converts bytes to JSON objects.
+            self.consumer = KafkaConsumer(
+                self.config.topic,
+                bootstrap_servers=self.config.bootstrap_servers,
+                value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+            )
+            # Informational log message on success
+            logger.info("Connected to Kafka topic %s", self.config.topic)
+        except Exception:  # pragma: no cover - difficult to simulate in unit tests
+            # Log unexpected exceptions and re-raise them
+            logger.exception("Failed to connect to Kafka")
+            raise
+
+    def upload_file(self, source: str, destination: str) -> None:
+        """Upload a local file to Azure using ``azcopy``."""
+
+        # Build the azcopy command. ``--overwrite=true`` ensures existing blobs
+        # are replaced so repeated uploads are safe.
+        cmd = [self.config.azcopy_path, "copy", source, destination, "--overwrite=true"]
+        try:
+            # Invoke azcopy; ``check=True`` raises an exception if the command
+            # exits with a non-zero status.
+            subprocess.run(cmd, check=True)
+            logger.info("Uploaded %s to %s", source, destination)
+        except subprocess.CalledProcessError:
+            # Log and propagate any azcopy errors to the caller
+            logger.exception("azcopy failed for %s", source)
+            raise
+
+    def consume_and_upload(self) -> None:
+        """Consume messages indefinitely and upload each record as a file."""
+
+        # Lazily create the Kafka consumer if it hasn't been created yet
+        if self.consumer is None:
+            self.connect()
+        # ``assert`` for static type checkers; ``self.consumer`` is not ``None``
+        assert self.consumer is not None
+
+        # Begin iterating over messages from Kafka
+        for message in self.consumer:
+            try:
+                # Message values are JSON objects thanks to the deserializer
+                data = message.value
+                # Persist each message to a uniquely named file
+                file_name = f"message_{message.offset}.json"
+                with open(file_name, "w", encoding="utf-8") as handle:
+                    json.dump(data, handle)
+
+                # After writing locally, upload the file to Azure
+                self.upload_file(file_name, self.config.azure_container_url)
+            except Exception:
+                # Log any exception but continue consuming subsequent messages
+                logger.exception(
+                    "Error processing message offset %s", message.offset
+                )
+

--- a/kafka_azure_consumer/tests/test_consumer.py
+++ b/kafka_azure_consumer/tests/test_consumer.py
@@ -1,0 +1,64 @@
+import json
+import unittest
+from unittest import mock
+
+from kafka_azure_consumer.consumer import ConsumerConfig, KafkaAzureConsumer
+
+
+class KafkaAzureConsumerTestCase(unittest.TestCase):
+    """Unit tests for KafkaAzureConsumer."""
+
+    @mock.patch("kafka_azure_consumer.consumer.KafkaConsumer")
+    def test_connect_creates_consumer(self, mock_consumer_cls):
+        config = ConsumerConfig(
+            bootstrap_servers="localhost:9092",
+            topic="test",
+            azure_container_url="https://example.com/container",
+            azcopy_path="azcopy",
+        )
+        consumer = KafkaAzureConsumer(config)
+        consumer.connect()
+        mock_consumer_cls.assert_called_once()
+        args, kwargs = mock_consumer_cls.call_args
+        self.assertIn(config.topic, args)
+        self.assertEqual(kwargs["bootstrap_servers"], config.bootstrap_servers)
+        self.assertTrue(callable(kwargs["value_deserializer"]))
+
+    @mock.patch("subprocess.run")
+    def test_upload_file_invokes_azcopy(self, mock_run):
+        config = ConsumerConfig(
+            bootstrap_servers="b",
+            topic="t",
+            azure_container_url="dest",
+            azcopy_path="azcopy",
+        )
+        consumer = KafkaAzureConsumer(config)
+        consumer.upload_file("src.json", "dest")
+        mock_run.assert_called_once()
+        cmd, = mock_run.call_args[0]
+        self.assertEqual(cmd[0], config.azcopy_path)
+        self.assertIn("--overwrite=true", cmd)
+
+    @mock.patch("kafka_azure_consumer.consumer.open", new_callable=mock.mock_open)
+    @mock.patch.object(KafkaAzureConsumer, "upload_file")
+    def test_consume_and_upload_processes_messages(self, mock_upload, mock_open):
+        # Mock consumer to yield two messages
+        fake_messages = [
+            mock.Mock(value={"a": 1}, offset=0),
+            mock.Mock(value={"b": 2}, offset=1),
+        ]
+        config = ConsumerConfig(
+            bootstrap_servers="b",
+            topic="t",
+            azure_container_url="dest",
+        )
+        consumer = KafkaAzureConsumer(config)
+        consumer.consumer = fake_messages  # directly assign iterable
+        consumer.consume_and_upload()
+        self.assertEqual(mock_upload.call_count, 2)
+        self.assertEqual(mock_open.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add simple Kafka consumer that uploads each message to Azure using azcopy
- document how to run consumer and tests
- provide unit tests covering consumer functionality

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'kafka')*

------
https://chatgpt.com/codex/tasks/task_e_6844a1ed0d1c83238f03c894bd700fe5