### PR TITLE
Add stub KafkaConsumer when library is missing

### DIFF
--- a/kafka_azure_consumer/consumer.py
+++ b/kafka_azure_consumer/consumer.py
@@ -6,7 +6,26 @@ import subprocess  # Used to invoke azcopy
 from dataclasses import dataclass
 from typing import Optional
 
-from kafka import KafkaConsumer  # Kafka client library
+try:
+    # Attempt to import the real Kafka client. In testing environments the
+    # ``kafka`` package may not be installed.
+    from kafka import KafkaConsumer  # type: ignore
+except ImportError:  # pragma: no cover - triggered when kafka-python missing
+    logging.getLogger(__name__).warning(
+        "kafka-python package not found; using stub KafkaConsumer"
+    )
+
+    class KafkaConsumer:  # Minimal stub for tests
+        """Fallback ``KafkaConsumer`` used when the real package is absent."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple stub
+            """Accept any arguments but perform no action."""
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
 
 # Configure root logger to output debug statements
 logging.basicConfig(level=logging.INFO)

--- a/kafka_azure_consumer/tests/test_consumer.py
+++ b/kafka_azure_consumer/tests/test_consumer.py
@@ -58,6 +58,29 @@ class KafkaAzureConsumerTestCase(unittest.TestCase):
         self.assertEqual(mock_upload.call_count, 2)
         self.assertEqual(mock_open.call_count, 2)
 
+    def test_import_without_kafka_package_uses_stub(self):
+        """Module should provide a stub ``KafkaConsumer`` when ``kafka`` is absent."""
+
+        import importlib
+        import sys
+
+        # Ensure a clean import of the consumer module
+        sys.modules.pop("kafka_azure_consumer.consumer", None)
+
+        with mock.patch.dict(sys.modules, {"kafka": None}):
+            module = importlib.import_module("kafka_azure_consumer.consumer")
+            importlib.reload(module)
+
+        config = module.ConsumerConfig(
+            bootstrap_servers="b",
+            topic="t",
+            azure_container_url="dest",
+        )
+        consumer = module.KafkaAzureConsumer(config)
+        # Should succeed using the stub KafkaConsumer
+        consumer.connect()
+        self.assertIsInstance(consumer.consumer, module.KafkaConsumer)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- provide a fallback KafkaConsumer implementation when `kafka` isn't installed
- add test ensuring the stub is used if the library cannot be imported

## Testing
- `python -m unittest discover -v -s kafka_azure_consumer/tests`

------
https://chatgpt.com/codex/tasks/task_e_684689a5aeb48323a74e08ce1d613132